### PR TITLE
Fix: Skip explicit undefined values in stringifyCSSProperties

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,52 @@
+# Manual Package Publishing Flow
+
+1. ✅ Make code changes
+
+Create a branch from `main`, commit and push your changes, then open a Pull Request.  
+Merge the PR into `main` after it's reviewed and tests pass.
+
+2. 🔄 Switch to the `main` branch
+
+Ensure you're on the latest `main` branch:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+3. 🔖 Bump the version using npm
+
+Use [semver](https://semver.org/) to choose the correct bump type:
+
+```bash
+npm version patch   # or minor / major
+```
+
+4. 🚀 Push changes and tags
+
+```bash
+git push
+git push origin vX.Y.Z
+```
+
+5. ✅ Run tests (before build)
+
+```bash
+npm test
+```
+
+6. 🧱 Build the package
+
+```bush
+npm run build
+```
+
+7. 📦 Publish to npm
+
+```bush
+npm publish
+```
+
+8. 📝 (Optional) Add release notes
+
+Create or edit a release on GitHub for the new tag and describe the changes.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "test": "vitest --config vitest.config.ts"
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
     "@emotion/unitless": "^0.10.0"

--- a/src/__tests__/stringifyCSSProperties.test.ts
+++ b/src/__tests__/stringifyCSSProperties.test.ts
@@ -25,13 +25,19 @@ describe("stringifyCSSProperties", () => {
     );
   });
 
-  it("throws error for wrong CSS-value", () => {
-    expect(() =>
+  it("skips CSS properties with wrong CSS value", () => {
+    const expected = "padding:5px 10px;color:teal;";
+    const actual = stringifyCSSProperties({
       //@ts-ignore
-      stringifyCSSProperties({ color: { color: "teal" } })
-    ).toThrowError(
-      "Invalid input: value of 'cssProperties' must be string or number."
-    );
+      margin: { top: 10 },
+      padding: "5px 10px",
+      background: undefined,
+      color: "teal",
+      //@ts-ignore
+      border: null,
+    });
+
+    expect(actual).toBe(expected);
   });
 
   it("doesn't change string CSS-value", () => {

--- a/src/stringifyCSSProperties.ts
+++ b/src/stringifyCSSProperties.ts
@@ -1,5 +1,5 @@
 import { type CSSProperties } from "react";
-import { applyCssUnits, camelToKebab } from "./utils";
+import { applyCssUnits, camelToKebab, isCSSPropertyValue } from "./utils";
 
 /**
  * Converts a CSSProperties object into a CSS string.
@@ -20,6 +20,7 @@ export function stringifyCSSProperties(
   const important = isImportant ? "!important" : "";
 
   return Object.entries(cssProperties)
+    .filter(([_, value]) => isCSSPropertyValue(value))
     .map(
       ([key, value]) =>
         `${camelToKebab(key)}:${applyCssUnits(key, value)}${important};`

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
 import { type CSSProperties } from "react";
 
-export type CSSSelector = string;
-
-export type StyleMap = Record<CSSSelector, CSSProperties>;
+export type StyleMap = Record<string, CSSProperties>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./camelToKebab";
 export * from "./isUnitless";
 export * from "./applyCssUnits";
 export * from "./trimCssSelector";
+export * from "./isCSSPropertyValue";

--- a/src/utils/isCSSPropertyValue.ts
+++ b/src/utils/isCSSPropertyValue.ts
@@ -1,0 +1,2 @@
+export const isCSSPropertyValue = (value: unknown): value is number | string =>
+  typeof value === "number" || typeof value === "string";


### PR DESCRIPTION
🛠️ Fix: Skip explicit undefined values in stringifyCSSProperties
This PR fixes #11 — handling cases where CSSProperties may contain value is explicitly set to `undefined`.

✅ Changes
Added a type guard to ensure only string or number values are processed.

Updated stringifyCSSProperties to skip properties with invalid values (undefined, null, objects, etc.).

Removed a test case that expected an error to be thrown for invalid input — since invalid values are now gracefully ignored.

Added new tests for undefined and null cases.

Added a publishing checklist doc (`docs/publishing.md`) with manual publishing instructions.

✅ Expected behavior
Previously, passing undefined values caused the lib to throw.
Now such values are silently skipped, ensuring safe and predictable behavior.